### PR TITLE
fix books with question mark not displaying the thumbnail

### DIFF
--- a/app/src/main/java/org/cis_india/wsreader/ui/common/BookItemCard.kt
+++ b/app/src/main/java/org/cis_india/wsreader/ui/common/BookItemCard.kt
@@ -109,7 +109,7 @@ fun BookItemCard(
                     )
                 } else {
                     AsyncImage(
-                        model = ImageRequest.Builder(LocalContext.current).data(coverImageUrl)
+                        model = ImageRequest.Builder(LocalContext.current).data(coverImageUrl.replace("?", "%3F"))
                             .crossfade(true).build(),
                         placeholder = painterResource(id = R.drawable.placeholder_cat),
                         contentDescription = stringResource(id = R.string.cover_image_desc),


### PR DESCRIPTION
Hi @bodhisattwawiki  Apparently the book title is included as part of the image url. When accessing the resource from the server the `_**?**_` acts as a starting point for query strings leading to not getting the correct resource. Below shows an example for the shared book.
<img width="1092" height="297" alt="querystrings" src="https://github.com/user-attachments/assets/3b4063e9-b411-4f48-b92a-d1a4f973dbee" />
