### PR TITLE
Disable MissingTranslation lint in Gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,6 +56,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    lint {
+        disable.add("MissingTranslation")
+    }
     lintOptions {
         abortOnError true
     }


### PR DESCRIPTION
This project is on translatewiki, which shows missing translation conveniently, and there is no need to see missing translation in the IDE.