### PR TITLE
Mark version number string resources and not translatable

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,9 +140,9 @@
 
     <string name="app_version_header">Version</string>
     <string name="app_version_label">App Version:</string>
-    <string name="app_version">2.2.0</string>
+    <string name="app_version" translatable="false">2.2.0</string>
     <string name="github_tab_label">GitHub Tag:</string>
-    <string name="github_tag">2.2.0</string>
+    <string name="github_tag" translatable="false">2.2.0</string>
 
     <string name="copyright_label">Copyright</string>
     <string name="copyright">\@ 2019 European Digital Reading Lab</string>


### PR DESCRIPTION
These translations are the same in all the languages and it's better not to translate them. If they are translated, they will be frequently outdated in translations.

(If anyone is very interested in using non-Western digits for this, it's possibly OK for the version number, and even then it's not recommended. And for the GitHub tag, it shouldn't be localized at all, because it's a specific string.)