### PR TITLE
Prevent multiple OutlineFragment instances on repeated menu clicks

### DIFF
--- a/app/src/main/java/org/cis_india/wsreader/reader/ReaderActivity.kt
+++ b/app/src/main/java/org/cis_india/wsreader/reader/ReaderActivity.kt
@@ -159,15 +159,18 @@ open class ReaderActivity : AppCompatActivity() {
     }
 
     private fun showOutlineFragment() {
-        supportFragmentManager.commit {
-            add(
-                R.id.activity_container,
-                OutlineFragment::class.java,
-                Bundle(),
-                OUTLINE_FRAGMENT_TAG
-            )
-            hide(readerFragment)
-            addToBackStack(null)
+        val outlineFragment = supportFragmentManager.findFragmentByTag(OUTLINE_FRAGMENT_TAG)
+        if(outlineFragment == null) {
+            supportFragmentManager.commit {
+                add(
+                    R.id.activity_container,
+                    OutlineFragment::class.java,
+                    Bundle(),
+                    OUTLINE_FRAGMENT_TAG
+                )
+                hide(readerFragment)
+                addToBackStack(null)
+            }
         }
     }
 


### PR DESCRIPTION
Previously, clicking the ≡ menu icon multiple times, quickly, would add multiple instances of the Outline fragment resulting in overlapping contents. 
Fix: Before adding OutlineFragment, we now check if it already exists in the FragmentManager using findFragmentByTag.
Tested by repeatedly tapping the ≡ menu icon multiple times very quickly and confirmed that only a single instance of OutlineFragment is ever created.