### PR TITLE
show read percentage in the library page

### DIFF
--- a/app/src/main/java/org/cis_india/wsreader/ui/screens/library/composables/LibraryScreen.kt
+++ b/app/src/main/java/org/cis_india/wsreader/ui/screens/library/composables/LibraryScreen.kt
@@ -645,19 +645,20 @@ fun CircularProgressWithText(
 
     Box(
         contentAlignment = Alignment.Center,
-        modifier = Modifier.size(24.dp)
+        modifier = Modifier.size(28.dp)
     ) {
         CircularProgressIndicator(
             progress = progressFloat,
-            modifier = Modifier.size(24.dp),
-            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(28.dp),
+            color = MaterialTheme.colorScheme.onSurface,
             trackColor = MaterialTheme.colorScheme.primaryContainer,
             strokeWidth = 1.dp
         )
 
         Text(
             text = "$progress%",
-            fontSize = 6.sp,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.SemiBold,
             color = MaterialTheme.colorScheme.onSurface,
         )
     }


### PR DESCRIPTION
Use book progression to show the readers percentage progress in the library page.

<img width="1080" height="1920" alt="Screenshot_20251018_192553" src="https://github.com/user-attachments/assets/ed61aa16-a432-48a9-b248-c69f6facf44f" />
