### PR TITLE
Added foreground permission for tts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />


### PR DESCRIPTION
Added the android.permission.FOREGROUND_SERVICE to the AndroidManifest.xml to allow MediaService to use startForeground() without crashing on modern Android versions.

[Screen_recording_20251103_115017.webm](https://github.com/user-attachments/assets/f270dc1a-c60e-4590-9cd1-6a376153d494)
