### PR TITLE
Fix download of books that have question mark (?) in the title.

### DIFF
--- a/app/src/main/java/org/cis_india/wsreader/helpers/book/BookDownloader.kt
+++ b/app/src/main/java/org/cis_india/wsreader/helpers/book/BookDownloader.kt
@@ -71,7 +71,11 @@ class BookDownloader(private val context: Context) {
                 .replace("\"", "")
                 .replace("/", "-")
                 .replace("\\", "-")
-                .replace("?", "")
+                .replace("?", "-")
+                .replace("*", "-")
+                .replace("<", "-")
+                .replace(">", "-")
+                .replace("|", "-")
                 .split(" ")
                 .joinToString(separator = "+") { word ->
                     word.replace(Regex("[^\\p{ASCII}]"), "")


### PR DESCRIPTION
**Problem:**
The book download failed because the question mark (?) in the title is an invalid for use with **File Class**.

**Solution:**
Replaced the invalid characters with a safe character "-"

[Screen_recording_20251112_131411.webm](https://github.com/user-attachments/assets/a36d7793-29a9-4724-8dcd-485328d7ede6)