### PR TITLE
update icon to represent published year

### DIFF
--- a/app/src/main/java/org/cis_india/wsreader/ui/screens/detail/composables/BookDetailScreen.kt
+++ b/app/src/main/java/org/cis_india/wsreader/ui/screens/detail/composables/BookDetailScreen.kt
@@ -523,7 +523,7 @@ private fun MiddleBar(
                 ) {
                     Row {
                         Icon(
-                            imageVector = ImageVector.vectorResource(id = R.drawable.ic_book_pages),
+                            imageVector = ImageVector.vectorResource(id = R.drawable.ic_published_year),
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.onBackground,
                             modifier = Modifier.padding(top = 13.dp, bottom = 15.dp, end = 4.dp)

--- a/app/src/main/res/drawable/ic_published_year.xml
+++ b/app/src/main/res/drawable/ic_published_year.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,22H5c-1.11,0 -2,-0.9 -2,-2L3.01,6c0,-1.1 0.88,-2 1.99,-2h1V2h2v2h8V2h2v2h1c1.1,0 2,0.9 2,2v6h-2v-2H5v10h7V22zM22.13,16.99l0.71,-0.71c0.39,-0.39 0.39,-1.02 0,-1.41l-0.71,-0.71c-0.39,-0.39 -1.02,-0.39 -1.41,0l-0.71,0.71L22.13,16.99zM21.42,17.7l-5.3,5.3H14v-2.12l5.3,-5.3L21.42,17.7z"/>
+    
+</vector>


### PR DESCRIPTION
changed published year icon to a calendar as pages would confuse users for number of pages. 

![537cfdd2-22a2-41db-8f72-722fde59747a](https://github.com/user-attachments/assets/d8584a99-4b3f-4702-8936-646814fe5a77)

