### PR TITLE
Redisign category top bar ui

### DIFF
--- a/app/src/main/java/org/cis_india/wsreader/ui/common/TopAppBars.kt
+++ b/app/src/main/java/org/cis_india/wsreader/ui/common/TopAppBars.kt
@@ -171,23 +171,23 @@ fun CustomTopAppBar(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(start = 20.dp, end = 20.dp, top = 16.dp, bottom = 8.dp)
+            .padding(start = 10.dp, end = 10.dp, top = 16.dp, bottom = 8.dp)
             .windowInsetsPadding(WindowInsets.statusBars)
     ) {
-        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-            Text(
-                text = headerText,
-                modifier = Modifier.padding(bottom = 16.dp),
-                color = MaterialTheme.colorScheme.onBackground,
-                fontStyle = MaterialTheme.typography.headlineMedium.fontStyle,
-                fontFamily = pacificoFont,
-                fontSize = 24.sp
-            )
+        Box(modifier = Modifier.fillMaxWidth()) {
             Row(
                 modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically
             ) {
                 TopBarActionItem(
                     icon = Icons.AutoMirrored.Outlined.ArrowBack, onclick = onBackButtonClicked
+                )
+                Text(
+                    text = headerText,
+                    modifier = Modifier.padding(bottom = 18.dp),
+                    color = MaterialTheme.colorScheme.onBackground,
+                    fontStyle = MaterialTheme.typography.headlineMedium.fontStyle,
+                    fontFamily = pacificoFont,
+                    fontSize = 24.sp
                 )
                 Spacer(modifier = Modifier.weight(1f))
                 TopBarActionItem(


### PR DESCRIPTION
Redesign cagetory top bar UI to avoid overlapping of title and icons
![3d02f4dc-9213-43f0-991a-772fa6ba06ca](https://github.com/user-attachments/assets/4e905435-f612-4605-b1a9-ac6024914a69)

